### PR TITLE
make Grid structure variable

### DIFF
--- a/pipeline/src/datastructure/PipelineGrid.cpp
+++ b/pipeline/src/datastructure/PipelineGrid.cpp
@@ -145,7 +145,7 @@ void PipelineGrid::drawContours(cv::Mat& img, const double transparency, const c
 		cv::Point _offset;
 	};
 
-    const int radius = static_cast<int>(std::ceil(_radius * FOCAL_LENGTH));
+    const int radius = static_cast<int>(std::ceil(_radius * _structure->FOCAL_LENGTH));
 	const cv::Point subimage_origin( std::max(       0, _center.x - radius), std::max(       0, _center.y - radius) );
 	const cv::Point subimage_end   ( std::min(img.cols, _center.x + radius), std::min(img.rows, _center.y + radius) );
 

--- a/pipeline/src/util/Util.cpp
+++ b/pipeline/src/util/Util.cpp
@@ -9,7 +9,8 @@
 
 namespace Util {
 
-std::array<gridconfig_t, 2> gridCandidatesFromEllipse(const pipeline::Ellipse& ellipse, const double rotation)
+std::array<gridconfig_t, 2> gridCandidatesFromEllipse(const pipeline::Ellipse& ellipse, const double rotation,
+													  const double focal_length)
 {
 	const cv::Point2i& cen = ellipse.getCen();
     const cv::Size2d& axes = ellipse.getAxis();
@@ -40,8 +41,8 @@ std::array<gridconfig_t, 2> gridCandidatesFromEllipse(const pipeline::Ellipse& e
 		                                         std::sin(theta_orth), std::cos(theta_orth));
 		const cv::Vec2d base_proj = shiftRotMat * base_x;
 
-		const cv::Point2i shiftedCen(static_cast<int>(cen.x + base_proj[0] * std::sin(roll) * major / Grid::FOCAL_LENGTH),
-		        static_cast<int>(cen.y + base_proj[1] * std::sin(roll) * major / Grid::FOCAL_LENGTH));
+		const cv::Point2i shiftedCen(static_cast<int>(cen.x + base_proj[0] * std::sin(roll) * major / focal_length),
+		        static_cast<int>(cen.y + base_proj[1] * std::sin(roll) * major / focal_length));
 		assert(shiftedCen.x > 0);
 		assert(shiftedCen.y > 0);
 

--- a/pipeline/util/Util.h
+++ b/pipeline/util/Util.h
@@ -3,6 +3,7 @@
 #include <bitset>
 #include <cstdint>
 #include <vector>
+#include <pipeline/common/Grid.h>
 
 #include "../datastructure/Ellipse.h"
 
@@ -17,7 +18,8 @@ typedef struct {
 } gridconfig_t;
 
 
-std::array<gridconfig_t, 2> gridCandidatesFromEllipse(const pipeline::Ellipse& ellipse, const double rotation = 0);
+std::array<gridconfig_t, 2> gridCandidatesFromEllipse(const pipeline::Ellipse& ellipse, const double rotation = 0,
+													  const double focal_length = Grid::Structure::DEFAULT_FOCAL_LENGTH);
 
 inline bool pointInBounds(cv::Rect const& bounds, cv::Point const& point) {
 	return (point.x >= bounds.tl().x &&


### PR DESCRIPTION
I would like to dynamically set Grid variables like the FOCAL_LENGTH and
the *_RING_RADIUS. This commit introduces the `Grid::Structure`
struct, which holds those variables.

For the pipeline use-case this commit adds an overhead of
an incrementation of a shared pointer, the default structure and
`_coordinates3D` are cached. Hope this is fine.

The `Grid::Structure` could be extended to also include the `NUM_MIDDLE_CELLS`.
